### PR TITLE
i18n tags, cleanup and patch nums setting

### DIFF
--- a/scripts/duty_names.py
+++ b/scripts/duty_names.py
@@ -1,0 +1,41 @@
+import csv
+import requests
+import time
+from bs4 import BeautifulSoup
+
+# This script takes the duties CSV file and generate text files
+# containing the duty names in each language.
+# --> Usage: python3 duty_names.py
+
+names = {
+    "fr": [],
+    "de": [],
+    "jp": []
+}
+
+with open("duties.csv", encoding='utf-8') as csvf: 
+    csvReader = csv.DictReader(csvf)
+
+    for row in csvReader:
+        lodestoneID = row["LodestoneID"]
+        for locale in names:
+            if (lodestoneID == ""):
+                names[locale].append("")
+                continue
+
+            url = "https://" + locale + ".finalfantasyxiv.com/lodestone/playguide/db/duty/" + row["LodestoneID"]
+            page = requests.get(url)
+
+            soup = BeautifulSoup(page.content, "html.parser")
+            results = soup.find("h2", class_="db-view__detail__lname_name")
+
+            name = results.text.strip()
+            names[locale].append(name)
+            print(name)
+
+            time.sleep(1)
+
+    for locale in names:
+        with open("duty_names_" + locale + ".txt", "w", encoding='utf-8') as f:
+            for name in names[locale]:
+                f.write(name + "\n")

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,5 +1,5 @@
 ## Build
-FROM golang:1.17-buster AS build
+FROM golang:1.20-buster AS build
 
 WORKDIR /app
 

--- a/server/handlers/auth.go
+++ b/server/handlers/auth.go
@@ -106,6 +106,10 @@ func getDiscordAuthResponse(discordAuthResponse *models.DiscordAuthResponse, cod
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != 200 {
+		return errors.New(resp.Status)
+	}
+
 	err = json.NewDecoder(resp.Body).Decode(discordAuthResponse)
 	if err != nil {
 		return err
@@ -126,6 +130,10 @@ func getDiscordUserResponse(discordUser *models.DiscordUser, discordAuthResponse
 		return err
 	}
 	defer resp.Body.Close()
+
+	rateLimitRemaining := resp.Header.Get("X-RateLimit-Remaining")
+	rateLimitLimit := resp.Header.Get("X-RateLimit-Limit")
+	log.Printf("rate limit for /users/@me: %s/%s", rateLimitRemaining, rateLimitLimit)
 
 	if resp.StatusCode != 200 {
 		return errors.New(resp.Status)

--- a/server/handlers/settings.go
+++ b/server/handlers/settings.go
@@ -66,5 +66,13 @@ func validateSettings(userData *models.User, payload *models.Settings) error {
 		return errors.New("CharacterClaimCode is immutable")
 	}
 
+	if payload.SpoilersOption < 0 || payload.SpoilersOption > 2 {
+		return errors.New("SpoilersOption invalid, must be between [0-2]")
+	}
+
+	if payload.PatchNumsOption < 0 || payload.PatchNumsOption > 2 {
+		return errors.New("PatchNumsOption invalid, must be between [0-2]")
+	}
+
 	return nil
 }

--- a/server/models/models.go
+++ b/server/models/models.go
@@ -34,6 +34,7 @@ type Settings struct {
 	LatestNewsSeen      int    `json:"latestNewsSeen"`
 	LatestCountdownSeen int    `json:"latestCountdownSeen"`
 	SpoilersOption      int    `json:"spoilersOption"`
+	PatchNumsOption     int    `json:"patchNumsOption"`
 }
 
 type Character struct {

--- a/src/App.vue
+++ b/src/App.vue
@@ -279,6 +279,7 @@ export default {
   },
   data() {
     return {
+      intervalFunction: null,
       tabFocused: true,
     };
   },
@@ -287,18 +288,18 @@ export default {
       this.setLanguage();
       this.checkUpstreamVersion();
       this.updateUserData();
-      setTimeout(() => this.updateCharactersData(), 10000);
+      setTimeout(() => this.updateCharactersData(), 1000 * 10); // 10 seconds
     });
-    setInterval(() => {
+    this.intervalFunction = setInterval(() => {
       if (this.tabFocused) {
         this.checkUpstreamVersion();
-      }
-    }, 1000 * 60); // 1 minute
-    setInterval(() => {
-      if (this.tabFocused) {
         this.updateCharactersData();
       }
     }, 1000 * 60); // 1 minute
+  },
+  unmounted() {
+    console.log("unmounted")
+    clearInterval(this.intervalFunction);
   },
   computed: {
     computeWindowTitle() {

--- a/src/App.vue
+++ b/src/App.vue
@@ -11,7 +11,10 @@
           msg="A new version is available! <a href='javascript:window.location.reload()' class='alert-link'>Reload and update the page</a>."
         />
       </div> -->
-      <div v-if="this.$store.state.signIn" class="container">
+      <div v-if="this.globalError" class="container">
+        <AlertMsg type="error" :msg="this.globalError" />
+      </div>
+      <div v-if="this.$store.state.signingIn == true" class="container">
         <AlertMsg type="normal" :msg="$t('message.signingDiscord')" />
       </div>
       <router-view />
@@ -304,8 +307,20 @@ export default {
       if (routeName === undefined || routeName === "Home") {
         return `XIV ToDo: ${this.$t("page.homeTitle")}`;
       } else {
+        // Erase any previous sign-in error
+        this.$store.commit("signingIn", false);
+
         const i18nRouteName = this.$t(`page.${routeName.toLowerCase()}`);
         return `XIV ToDo - ${i18nRouteName}`;
+      }
+    },
+    globalError() {
+      if (this.$store.state.signingIn?.status == 401) {
+        return this.$t("message.signingUnauthorizedError");
+      } else if (this.$store.state.signingIn?.status == 500) {
+        return this.$t("message.signingUnknownError");
+      } else {
+        return "";
       }
     },
   },

--- a/src/App.vue
+++ b/src/App.vue
@@ -11,12 +11,6 @@
           msg="A new version is available! <a href='javascript:window.location.reload()' class='alert-link'>Reload and update the page</a>."
         />
       </div> -->
-      <div
-        v-if="this.$store.state.characters && this.$store.state.characters.length > 0"
-        class="container"
-      >
-        <AlertMsg type="normal" :msg="getMigrationMessage()" />
-      </div>
       <div v-if="this.$store.state.signIn" class="container">
         <AlertMsg type="normal" :msg="$t('message.signingDiscord')" />
       </div>
@@ -344,42 +338,6 @@ export default {
       window.addEventListener("blur", onWindowFocusChange);
       window.addEventListener("pageshow", onWindowFocusChange);
       window.addEventListener("pagehide", onWindowFocusChange);
-    },
-    // @TODO: remove this after a few months
-    getMigrationMessage() {
-      let str =
-        "Since the last time you've used XIV ToDo, support for Discord sign ins was added.<br /><br />" +
-        "This means being able to sign in from multiple places (like both your desktop and your mobile), and keeping the data in-sync. " +
-        "To help you start out with the new account system, below is a list of your previously-added characters.<br />";
-
-      for (let character of this.$store.state.characters) {
-        str +=
-          "<br />&nbsp;&nbsp;&nbsp;" +
-          "<a href='https://na.finalfantasyxiv.com/lodestone/character/" +
-          character.characterData.Character.ID +
-          "' class='alert-link'>" +
-          character.characterData.Character.Name +
-          "</a>";
-        if (character.todosCustomWeeklies && character.todosCustomWeeklies.length > 0) {
-          str += "<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Custom weeklies:";
-          for (let weekly of character.todosCustomWeeklies) {
-            str += " '" + weekly.Name + "'";
-          }
-        }
-        if (character.todosCustomDailies && character.todosCustomDailies.length > 0) {
-          str += "<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Custom dailies:";
-          for (let weekly of character.todosCustomDailies) {
-            str += " '" + weekly.Name + "'";
-          }
-        }
-      }
-
-      str +=
-        "<br /><br />Make sure to note this information down, as it will disappear once you <a href='" +
-        this.$store.state.env.VUE_APP_DISCORD_AUTH_URI +
-        "' class='alert-link'>sign in with Discord</a>. Need help? Visit the new <a href='https://discord.gg/zfzhKhG3zj' target='_blank' rel='noopener noreferrer' class='alert-link'>Discord</a> server or <a href='https://twitter.com/XIVToDo' target='_blank' rel='noopener noreferrer' class='alert-link'>Twitter</a>!";
-
-      return str;
     },
     setLanguage() {
       if (this.$store.getters.language === null) {

--- a/src/assets/news.json
+++ b/src/assets/news.json
@@ -2,13 +2,6 @@
   "latestCountdownID": 27,
   "countdowns": [
     {
-      "title": "Hatching-tide",
-      "description": "The 2023 edition of the Hatching-tide event.",
-      "url": "https://na.finalfantasyxiv.com/lodestone/special/2023/Hatching_tide/gkonsy0g3l",
-      "start": 1679904000,
-      "end": 1681138800
-    },
-    {
       "title": "Patch 6.35",
       "description": "Release of patch 6.35.",
       "url": "https://na.finalfantasyxiv.com/lodestone/topics/detail/549b10141c2add85f11595f5ba39127cc0433327/",

--- a/src/assets/news.json
+++ b/src/assets/news.json
@@ -9,13 +9,6 @@
       "end": 1681138800
     },
     {
-      "title": "Letter from the Producer LIVE Part LXXVI",
-      "description": "Upcoming LPL keynote for patch 6.4 and miscellaneous updates.",
-      "url": "https://na.finalfantasyxiv.com/lodestone/topics/detail/1160542ee9942500b397c83fca8ca1f3cf23f423",
-      "start": 1680260400,
-      "end": 1680271200
-    },
-    {
       "title": "Patch 6.35",
       "description": "Release of patch 6.35.",
       "url": "https://na.finalfantasyxiv.com/lodestone/topics/detail/549b10141c2add85f11595f5ba39127cc0433327/",

--- a/src/components/DutyListItem.vue
+++ b/src/components/DutyListItem.vue
@@ -65,7 +65,7 @@
       :title="$t('encounters.msqContent')"
     ></span>
     <span
-      v-if="duty.Expansion && duty.blur"
+      v-if="duty.Expansion && showPatchNums"
       :class="'icon-exp-' + duty.Expansion"
       data-bs-toggle="tooltip"
       data-bs-placement="top"
@@ -130,6 +130,15 @@ export default {
   computed: {
     title() {
       return this.duty.LodestoneID || this.duty.blur ? "" : this.duty.Name;
+    },
+    showPatchNums() {
+      let patchNumsSetting = this.$store.getters.settings.patchNumsOption || 0;
+
+      return (
+        (patchNumsSetting == 0 && this.duty.blur) ||
+        (patchNumsSetting == 1 && this.duty.cleared != 1 && this.duty.cleared != 2) ||
+        patchNumsSetting == 2
+      );
     },
   },
   methods: {

--- a/src/components/TheNavbar.vue
+++ b/src/components/TheNavbar.vue
@@ -51,7 +51,7 @@
                 data-bs-toggle="dropdown"
                 aria-expanded="false"
               >
-                Collection
+              {{ $t("page.collection") }}
               </a>
               <ul
                 class="dropdown-menu dropdown-menu-end dropdown-menu-dark"
@@ -59,13 +59,16 @@
               >
                 <li>
                   <router-link to="/achievements" class="dropdown-item" @click="collapseNav">
-                    <i class="fa-fw fad fa-award"></i> {{ $t("page.achievements") }}
+                    <i class="fa-fw fal fa-trophy"></i> {{ $t("page.achievements") }}
+                  </router-link>
+                  <router-link to="/titles" class="dropdown-item" @click="collapseNav">
+                    <i class="fa-fw fal fa-scroll"></i> {{ $t("page.titles") }}
                   </router-link>
                   <router-link to="/mounts" class="dropdown-item" @click="collapseNav">
-                    <i class="fa-fw fad fa-horse-saddle"></i> {{ $t("page.mounts") }}
+                    <i class="fa-fw fal fa-horse-saddle"></i> {{ $t("page.mounts") }}
                   </router-link>
                   <router-link to="/minions" class="dropdown-item" @click="collapseNav">
-                    <i class="fa-fw fad fa-cat-space"></i> {{ $t("page.minions") }}
+                    <i class="fa-fw fal fa-cat-space"></i> {{ $t("page.minions") }}
                   </router-link>
                 </li>
               </ul>
@@ -466,6 +469,8 @@ export default {
       if (!this.$store.getters.isSignedIn) return;
 
       let settings = { ...this.$store.getters.settings };
+      if (settings.latestNewsSeen == news.latestID) return;
+
       settings.latestNewsSeen = news.latestID;
       this.$store.commit("setSettings", settings);
       updateSettings(settings);
@@ -474,6 +479,8 @@ export default {
       if (!this.$store.getters.isSignedIn) return;
 
       let settings = { ...this.$store.getters.settings };
+      if (settings.latestCountdownSeen == news.latestCountdownID) return;
+
       settings.latestCountdownSeen = news.latestCountdownID;
       this.$store.commit("setSettings", settings);
       updateSettings(settings);

--- a/src/components/TheNavbar.vue
+++ b/src/components/TheNavbar.vue
@@ -258,7 +258,7 @@
                   </h6>
                 </li>
                 <li>
-                  <a class="dropdown-item cursor-pointer" @click="signOut">
+                  <a class="dropdown-item" href="#" @click="signOut">
                     <i class="fa-fw fal fa-power-off"></i> {{ $t("page.signOut") }}
                   </a>
                 </li>

--- a/src/i18n/lang-en.json
+++ b/src/i18n/lang-en.json
@@ -7,6 +7,7 @@
     "questlines": "Questlines",
     "challenges": "Challenges",
     "achievements": "Achievements",
+    "titles": "Titles",
     "minions": "Minions",
     "mounts": "Mounts",
     "checklist": "Checklist",
@@ -38,6 +39,8 @@
   "message": {
     "backendUnavailable": "XIV ToDo is currently unreachable. Try again later, or look on <a href='https://twitter.com/XIVToDo' class='alert-link' target='_blank' rel='noopener noreferrer'>Twitter</a> or <a href='https://discord.gg/zfzhKhG3zj' class='alert-link' target='_blank' rel='noopener noreferrer'>Discord</a> for a status update.",
     "signingDiscord": "Signing in with Discord...",
+    "signingUnauthorizedError": "XIV ToDo was unable to authenticate with Discord. Make sure you are using valid Discord credentials.",
+    "signingUnknownError": "XIV ToDo was unable to reach Discord. Try again later, or look on <a href='https://twitter.com/XIVToDo' class='alert-link' target='_blank' rel='noopener noreferrer'>Twitter</a> or <a href='https://discord.gg/zfzhKhG3zj' class='alert-link' target='_blank' rel='noopener noreferrer'>Discord</a> for a status update.",
     "updatingCharacter": "Updating character data, this may take a minute...",
     "achievementsNotPublic": "The achievements for this character are not set to public in Lodestone.",
     "notSignedIn": "No characters found. You can <a href='{url}' class='alert-link'>sign in with Discord</a> to add them.",

--- a/src/i18n/lang-en.json
+++ b/src/i18n/lang-en.json
@@ -6,6 +6,7 @@
     "encounters": "Encounters",
     "questlines": "Questlines",
     "challenges": "Challenges",
+    "collection": "Collection",
     "achievements": "Achievements",
     "titles": "Titles",
     "minions": "Minions",
@@ -90,6 +91,47 @@
       "header": "About XIV ToDo",
       "text": "XIV ToDo is a project started in mid-2021 by {0}, a software developer from Canada. After realizing that there were no methods for quickly visualizing which of the numerous encounters and questlines that had been cleared by my characters, the idea had sparked. XIV ToDo is and remains free for everyone to enjoy. You can {1} with any question or feedback. Thank you so much for using and supporting this project!",
       "contact": "contact me"
+    }
+  },
+  "help": {
+    "discordSignIn": {
+      "header": "Discord sign-in",
+      "text": "To use XIV ToDo, you must sign in with a Discord account. This is an official authentication integration provided by Discord and is very secure, since no confidential information is ever stored."
+    },
+    "addingCharacters": {
+      "header": "Adding characters",
+      "text1": "To add one of your characters, you first find its Lodestone URL. You can find it by logging into {0} and searching for your character profile. Your Lodestone URL will look similar to this example:",
+      "text2": "Once you have found your profile URL, you can input it in the {0} page and then click the {1} button. You can add as many as 8 characters, and switch between them at any time using the dropdown at the end of the main navigation bar."
+    },
+    "freeTrialCharacters": {
+      "header": "Free trial characters",
+      "text": "Free trial characters are supported in XIV ToDo and can be added, but since the Lodestone privacy settings are unavailable on the free trial, the automatic completion tracker will not work for those characters."
+    },
+    "enablingPublicAchievements": {
+      "header": "Enabling public achievements",
+      "text1": "If you add a character and their encounter and questline completions aren't getting registered, it's likely that the achievements are not set to visible publicly for that character. You can verify this by logging into {0}, and then accessing the {1} section. From there, make sure {2} is set to {3} and save the changes.",
+      "text2": "Once your achievements are public, you may need to re-add your character or refresh it from the {0} page on XIV ToDo for it to take effect.",
+      "lodestoneAccountManagement": "Account Management",
+      "lodestonePublic": "Public"
+    },
+    "customizingCharacterChecklists": {
+      "header": "Customizing character checklists",
+      "text": "Daily and weekly checklists can be customized by clicking on the {0} button near the top right of the {1} page. From there, you can add custom entries as well as hide entries that you don't want to see. To stop customizing, simply click the {2} button again."
+    },
+    "encounterQuestlineCompletion": {
+      "header": "Encounter and questline completion",
+      "text1": "Encounter and questlines are automatically marked as cleared once the relevant achievements have been obtained. Since encounters or questlines don't always map directly directly to in-game achievement, automated completion tracking is not always fully accurate. You can correct the tracking by manually marking the encounter or questline as cleared.",
+      "text2": "XIV ToDo takes in-game achievements data from the Lodestone, which can take a few hours to be up-to-date. Once a new in-game achievement is obtained, it may take up to 48 hours for the relevant encounter or questline to be marked as complete in XIV ToDo. You can also manually initiate a refresh of the data from the {0} page.",
+      "textState": "The following are the four possible statuses for each encounter and questline:",
+      "stateClearedVerified": "Your active character has cleared this encounter (verified).",
+      "stateCleared": "Your active character has cleared this encounter.",
+      "stateUnknown": "Your active character's current achievements cannot determine encounter clear.",
+      "stateNotCleared": "Your active character has not cleared this encounter yet."
+    },
+    "otherQuestions": {
+      "header": "Other questions",
+      "text": "Contact me {0}, on {1} or on {2} and I will reply as soon as possible.",
+      "textHere": "here"
     }
   },
   "profile": {
@@ -258,8 +300,12 @@
       "settingsNotUpdated": "Settings could not be updated: {error}",
       "characterAdded": "Character <b>{name}</b> added! You can now access your <a href='/profile' class='alert-link'>Profile</a> and all character completion pages.",
       "characterAddedNotPublic": "Character <b>{name}</b> added, but their achievements are not set to public. You can change that setting <a href='https://na.finalfantasyxiv.com/lodestone/my/setting/account/' class='alert-link' target='_blank' rel='noopener noreferrer'>here</a>, and then update the character's data.",
+      "characterAddNotFoundError": "The character profile you have entered does not exist.",
+      "characterAddClientError": "Could not add character. You may have already added this character, or have reached the limit of characters.",
+      "characterAddServerError": "Could not reach Lodestone. There may be an ongoing maintenance. Please try again later.",
       "characterRemoveConfirm": "Are you sure you want to remove {name}?",
-      "characterRemoved": "Character <b>{name}</b> removed!"
+      "characterRemoved": "Character <b>{name}</b> removed!",
+      "characterRemoveError": "Character <b>{name}</b> could not be removed. Please try again later."
     }
   },
   "shared": {

--- a/src/i18n/lang-en.json
+++ b/src/i18n/lang-en.json
@@ -287,17 +287,25 @@
     "general": "General",
     "contentSpoilers": {
       "label": "Content spoilers",
-      "option0": "Blur out all story-related encounters",
-      "option1": "Blur out non-completed story-related encounters",
-      "option2": "Show all encounters",
+      "option0": "Blur out non-completed story-related content",
+      "option1": "Blur out all story-related content",
+      "option2": "Show all content",
       "hint": "Preference in hiding potential spoilers."
+    },
+    "patchNumbers": {
+      "label": "Patch numbers",
+      "option0": "Show patch numbers for blurred out content",
+      "option1": "Show patch numbers for non-completed content",
+      "option2": "Always show patch numbers",
+      "hint": "Preference in showing patch numbers for content."
     },
     "updateSettings": "Update settings",
     "achievementsNotPublic": "Achievements are not public",
     "achievementsNotPublicAlt": "The achievements for this character are not set to public in Lodestone",
     "message": {
       "settingsUpdated": "Settings updated!",
-      "settingsNotUpdated": "Settings could not be updated: {error}",
+      "settingsUpdateClientError": "Could not update settings. You may have entered invalid settings.",
+      "settingsUpdateUnknownError": "Could not update settings. Please try again later.",
       "characterAdded": "Character <b>{name}</b> added! You can now access your <a href='/profile' class='alert-link'>Profile</a> and all character completion pages.",
       "characterAddedNotPublic": "Character <b>{name}</b> added, but their achievements are not set to public. You can change that setting <a href='https://na.finalfantasyxiv.com/lodestone/my/setting/account/' class='alert-link' target='_blank' rel='noopener noreferrer'>here</a>, and then update the character's data.",
       "characterAddNotFoundError": "The character profile you have entered does not exist.",

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -27,12 +27,11 @@ const routes = [
           store.commit("setUserData", userData);
         })
         .catch((err) => {
-          // @TODO: handle rendering error to user
-          store.commit("signIn", false);
+          store.commit("signingIn", err);
           console.log(err);
         });
 
-      store.commit("signIn", true);
+      store.commit("signingIn", true);
       next("/");
     },
   },

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -143,18 +143,6 @@ const store = createStore({
     },
 
     signIn(state, payload) {
-      // @TODO: deprecate this cleanup step
-      delete state.characters;
-      delete state.characterData;
-      delete state.latestNewsSeen;
-      delete state.latestNewsSeenPrevious;
-      delete state.latestCountdownSeen;
-      delete state.settings;
-      delete state.todosChecked;
-      delete state.todosHidden;
-      delete state.todosNextDailyReset;
-      delete state.todosNextWeeklyReset;
-
       state.signIn = payload;
     },
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -142,8 +142,8 @@ const store = createStore({
       state.env = process.env;
     },
 
-    signIn(state, payload) {
-      state.signIn = payload;
+    signingIn(state, payload) {
+      state.signingIn = payload;
     },
 
     setUpstreamVersion(state, payload) {
@@ -161,7 +161,7 @@ const store = createStore({
         state.userData.characters = [];
       }
 
-      delete state.signIn;
+      delete state.signingIn;
     },
     deleteUserData(state) {
       state.userData = null;

--- a/src/utilities/backend.js
+++ b/src/utilities/backend.js
@@ -161,7 +161,7 @@ const updateSettings = (payload) =>
         resolve(settings);
       })
       .catch((err) => {
-        reject("Could not update settings: " + err);
+        reject(err);
       });
   });
 
@@ -186,17 +186,7 @@ const addCharacter = (id) =>
         resolve(characterData);
       })
       .catch((err) => {
-        if (err.status == 404) {
-          reject("The character profile you have entered does not exist.");
-        } else if (err.status == 400) {
-          reject(
-            "Could not add character. You may have already added this character, or have reached the limit of characters. "
-          );
-        } else {
-          reject(
-            "Could not reach Lodestone; There may be an ongoing maintenance. Please try again later."
-          );
-        }
+        reject(err);
       });
   });
 
@@ -217,7 +207,7 @@ const removeCharacter = (id) =>
         }
       })
       .catch((err) => {
-        reject("Could not delete character. Please try again later." + err);
+        reject(err);
       });
   });
 
@@ -239,7 +229,7 @@ const updateChecklist = (id, payload) =>
         }
       })
       .catch((err) => {
-        reject("Could not update checklist. Please try again later." + err);
+        reject(err);
       });
   });
 
@@ -261,7 +251,7 @@ const updateEncounterIDs = (id, payload) =>
         }
       })
       .catch((err) => {
-        reject("Could not update encounter IDs. Please try again later." + err);
+        reject(err);
       });
   });
 

--- a/src/views/Help.vue
+++ b/src/views/Help.vue
@@ -4,134 +4,115 @@
     <hr />
     <div class="row">
       <div class="col-lg-10 indent-paragraphs">
-        <h2>Discord sign-in</h2>
+        <h2>{{ $t("help.discordSignIn.header") }}</h2>
+        <p>{{ $t("help.discordSignIn.text") }}</p>
+
+        <br />
+        <h2>{{ $t("help.addingCharacters.header") }}</h2>
         <p>
-          To use XIV ToDo, you must sign in with a Discord account. This is an official
-          authentication integration provided by Discord and allows for a much more secure system
-          than a XIV ToDo-specific username and password would be, since no confidential information
-          needs to be stored. By signing in with your Discord account, it provides your Discord
-          username (but not your password) which is used to map to your characters, checklists, and
-          completion.
+          <i18n-t keypath="help.addingCharacters.text1">
+            <a :href="getLodestoneURL()" target="_blank" rel="noopener noreferrer">
+              {{ $t("shared.lodestone") }}
+            </a>
+          </i18n-t>
+        </p>
+        <p>
+          <span class="font-monospace"> {{ getLodestoneURL() }}character/12345/</span>
+        </p>
+        <p>
+          <i18n-t keypath="help.addingCharacters.text2">
+            <router-link to="/settings">{{ $t("page.settings") }}</router-link>
+            <b>{{ $t("settings.addCharacter") }}</b>
+          </i18n-t>
         </p>
 
         <br />
-        <h2>Adding characters</h2>
+        <h2>{{ $t("help.freeTrialCharacters.header") }}</h2>
+        <p>{{ $t("help.freeTrialCharacters.text") }}</p>
+
+        <br />
+        <h2>{{ $t("help.enablingPublicAchievements.header") }}</h2>
         <p>
-          To add one of your characters, you first find its Lodestone URL. You can find it by
-          logging into
-          <a
-            href="https://na.finalfantasyxiv.com/lodestone/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Lodestone</a
-          >
-          and searching for your character profile. Your Lodestone URL will look similar to this
-          example:
-          <span class="font-monospace">
-            https://na.finalfantasyxiv.com/lodestone/character/32741501/
+          <i18n-t keypath="help.enablingPublicAchievements.text1">
+            <a :href="getLodestoneURL()" target="_blank" rel="noopener noreferrer">
+              {{ $t("shared.lodestone") }}
+            </a>
+            <a
+              :href="getLodestoneURL() + 'my/setting/account/'"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+            {{ $t("help.enablingPublicAchievements.lodestoneAccountManagement") }}
+            </a>
+            <b>{{ $t("page.achievements") }}</b>
+            <b>{{ $t("help.enablingPublicAchievements.lodestonePublic") }}</b>
+          </i18n-t>
+        </p>
+        <p>
+          <i18n-t keypath="help.enablingPublicAchievements.text2">
+            <router-link to="/settings">{{ $t("page.settings") }}</router-link>
+          </i18n-t>
+        </p>
+
+        <br />
+        <h2>{{ $t("help.customizingCharacterChecklists.header") }}</h2>
+        <p>
+          <i18n-t keypath="help.customizingCharacterChecklists.text">
+            <b>{{ $t("shared.customize") }}</b>
+            <router-link to="/checklist">{{ $t("page.checklist") }}</router-link>
+            <b>{{ $t("shared.customize") }}</b>
+          </i18n-t>
+        </p>
+
+        <br />
+        <h2>{{ $t("help.encounterQuestlineCompletion.header") }}</h2>
+        <p>{{ $t("help.encounterQuestlineCompletion.text1") }}</p>
+        <p>
+          <i18n-t keypath="help.encounterQuestlineCompletion.text2">
+            <router-link to="/settings">{{ $t("page.settings") }}</router-link>
+          </i18n-t>
+        </p>
+        <p>{{ $t("help.encounterQuestlineCompletion.textState") }}</p>
+        <p>
+          <span class="text-success">
+            <i class="fa-fw fal fa-badge-check text-success"></i>
+            {{ db.arrDungeons[0]["Name" + $i18n.locale.toUpperCase()] }}
           </span>
-        </p>
-        <p>
-          Once you have found your profile URL, you can input it in the
-          <router-link to="/settings">Settings</router-link> page and then click the
-          <b>Add character</b> button.
-        </p>
-        <p>
-          You can add as many as 8 characters, and switch between them at any time using the
-          dropdown at the end of the main navigation bar.
-        </p>
-
-        <br />
-        <h2>Free trial characters</h2>
-        <p>
-          Free trial characters are supported in XIV ToDo and can be added, but since the Lodestone
-          privacy settings are unavailable on those accounts, the automatic completion tracker does
-          not work for those characters.
-        </p>
-
-        <br />
-        <h2>Enabling public achievements</h2>
-        <p>
-          If you add a character and your encounter and questline completions aren't getting
-          registered, likely the achievements are not set to public visibility for that character.
-          You can verify this by logging into
-          <a
-            href="https://na.finalfantasyxiv.com/lodestone/"
-            target="_blank"
-            rel="noopener noreferrer"
-            >Lodestone</a
-          >, and then accessing the
-          <a
-            href="https://na.finalfantasyxiv.com/lodestone/my/setting/account/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Account Management</a
-          >
-          section. From there, make sure <b>Achievements</b> is set to <b>Public</b> and click
-          <b>Confirm</b>.
-        </p>
-        <p>
-          Once your achievements are public, you may need to re-add your character or refresh it via
-          the <router-link to="/settings">Settings</router-link> page on XIV ToDo for it to take
-          effect.
+          <br />
+          &nbsp;&nbsp;{{ $t("help.encounterQuestlineCompletion.stateClearedVerified") }}<br />
+          <span class="text-success">
+            <i class="fa-fw fal fa-check-circle text-success"></i>
+            {{ db.arrDungeons[0]["Name" + $i18n.locale.toUpperCase()] }}
+          </span>
+          <br />
+          &nbsp;&nbsp;{{ $t("help.encounterQuestlineCompletion.stateCleared") }}<br />
+          <span class="text-secondary"><i class="fa-fw fal fa-question-circle"></i>
+            {{ db.arrDungeons[0]["Name" + $i18n.locale.toUpperCase()] }}
+          </span>
+          <br />
+          &nbsp;&nbsp;{{ $t("help.encounterQuestlineCompletion.stateUnknown") }}<br />
+          <span>
+            <i class="fa-fw fal fa-circle"></i>
+            {{ db.arrDungeons[0]["Name" + $i18n.locale.toUpperCase()] }}
+          </span>
+          <br />
+          &nbsp;&nbsp;{{ $t("help.encounterQuestlineCompletion.stateNotCleared") }}
         </p>
 
         <br />
-        <h2>Customizing character checklists</h2>
+        <h2>{{ $t("help.otherQuestions.header") }}</h2>
         <p>
-          Daily and weekly checklists can be customized by clicking on the
-          <b>Customize</b> button near the top right of the
-          <router-link to="/checklist">Checklist</router-link> page. From there, you can add custom
-          entries as well as hide entries that you don't want to see. To stop customizing, simply
-          click the <b>Customize</b> button again.
-        </p>
-
-        <br />
-        <h2>Encounter and questline completion</h2>
-        <p>
-          Encounter and questlines are automatically marked as cleared once the relevant
-          achievements have been obtained. Since encounters or questlines don't always map directly
-          directly to in-game achievement, automated completion tracking is not always fully
-          accurate. You can correct the tracking by clicking on the encounter or questline.
-        </p>
-        <p>
-          XIV ToDo takes in-game achievements data from the Lodestone, which can take multiple hours
-          to be up-to-date. Once a new in-game achievement is obtained, it may take up to 48 hours
-          for the relevant encounter or questline to be marked as complete in XIV ToDo. You can also
-          try forcing a refresh of the data through the
-          <router-link to="/settings">Settings</router-link>.
-        </p>
-        <p>The following are the four possible statuses for each encounter and questline:</p>
-        <p>
-          <span class="text-success"><i class="fa-fw fal fa-badge-check text-success"></i> Sastasha</span><br />
-          &nbsp;&nbsp;Your active character has cleared this encounter (verified).<br />
-          <span class="text-success"><i class="fa-fw fal fa-check-circle text-success"></i> Sastasha</span><br />
-          &nbsp;&nbsp;Your active character has cleared this encounter.<br />
-          <span class="text-secondary"><i class="fa-fw fal fa-question-circle"></i> Sastasha</span><br />
-          &nbsp;&nbsp;Your active character's current achievements cannot determine encounter
-          clear.<br />
-          <span><i class="fa-fw fal fa-circle"></i> Sastasha</span><br />
-          &nbsp;&nbsp;Your active character has not cleared this encounter yet.
-        </p>
-
-        <br />
-        <h2>Other questions</h2>
-        <p>
-          Contact me
-          <a href="https://forms.gle/2t5nLB28xDyi3Tn6A" target="_blank" rel="noopener noreferrer">
-            on this form</a
-          >
-          , on
-          <a href="https://discord.gg/zfzhKhG3zj" target="_blank" rel="noopener noreferrer">
-            Discord</a
-          >
-          or on
-          <a href="https://twitter.com/xivtodo" target="_blank" rel="noopener noreferrer">
-            Twitter</a
-          >
-          and I will reply as soon as possible.
+          <i18n-t keypath="help.otherQuestions.text">
+            <a href="https://forms.gle/2t5nLB28xDyi3Tn6A" target="_blank" rel="noopener noreferrer">
+              {{ $t("help.otherQuestions.textHere") }}
+            </a>
+            <a href="https://discord.gg/zfzhKhG3zj" target="_blank" rel="noopener noreferrer">
+              {{ $t("page.discord") }}
+            </a>
+            <a href="https://twitter.com/xivtodo" target="_blank" rel="noopener noreferrer">
+              {{ $t("page.twitter") }}
+            </a>
+          </i18n-t>
         </p>
         <br />
       </div>
@@ -140,7 +121,18 @@
 </template>
 
 <script>
+import dbJson from "@/assets/db.json";
+import { getLodestoneURL } from "@/utilities/shared.js";
+
 export default {
   name: "HelpView",
+  data() {
+    return {
+      db: dbJson,
+    };
+  },
+  methods: {
+    getLodestoneURL: getLodestoneURL,
+  },
 };
 </script>

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -293,7 +293,23 @@ export default {
         })
         .catch((err) => {
           console.log(err);
-          this.error = { type: "error", msg: err.toString() };
+
+          if (err.status == 404) {
+            this.error = {
+              type: "error",
+              msg: this.$t("settings.message.characterAddNotFoundError"),
+            };
+          } else if (err.status == 400) {
+            this.error = {
+              type: "error",
+              msg: this.$t("settings.message.characterAddClientError"),
+            };
+          } else {
+            this.error = {
+              type: "error",
+              msg: this.$t("settings.message.characterAddServerError"),
+            };
+          }
         })
         .finally(() => {
           this.profileURL = "";
@@ -340,7 +356,10 @@ export default {
         })
         .catch((err) => {
           console.log(err);
-          this.error = { type: "error", msg: err.toString() };
+          this.error = {
+            type: "error",
+            msg: this.$t("settings.message.characterRemoveError", { name: characterName }),
+          };
         })
         .finally(() => {
           this.updating = false;

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -132,6 +132,7 @@
           </ul>
           <br />
         </div>
+
         <div class="col-lg-6">
           <h2>{{ $t("settings.general") }}</h2>
           <h3>{{ $t("settings.contentSpoilers.label") }}</h3>
@@ -175,7 +176,52 @@
             </label>
           </div>
           <div class="form-text">{{ $t("settings.contentSpoilers.hint") }}</div>
+
           <br />
+
+          <h3>{{ $t("settings.patchNumbers.label") }}</h3>
+          <div class="form-check">
+            <input
+              v-model="settings.patchNumsOption"
+              class="form-check-input"
+              type="radio"
+              name="inputPatchNumsOption"
+              id="inputPatchNumsOption0"
+              :value="0"
+            />
+            <label class="form-check-label" for="inputPatchNumsOption0">
+              {{ $t("settings.patchNumbers.option0") }}
+            </label>
+          </div>
+          <div class="form-check">
+            <input
+              v-model="settings.patchNumsOption"
+              class="form-check-input"
+              type="radio"
+              name="inputPatchNumsOption"
+              id="inputPatchNumsOption1"
+              :value="1"
+            />
+            <label class="form-check-label" for="inputPatchNumsOption1">
+              {{ $t("settings.patchNumbers.option1") }}
+            </label>
+          </div>
+          <div class="form-check">
+            <input
+              v-model="settings.patchNumsOption"
+              class="form-check-input"
+              type="radio"
+              name="inputPatchNumsOption"
+              id="inputPatchNumsOption2"
+              :value="2"
+            />
+            <label class="form-check-label" for="inputPatchNumsOption2">
+              {{ $t("settings.patchNumbers.option2") }}
+            </label>
+          </div>
+          <div class="form-text">{{ $t("settings.patchNumbers.hint") }}</div>
+          <br />
+
           <button
             v-if="updatingSettings"
             type="button"
@@ -193,7 +239,7 @@
             id="settings-save-btn"
             class="btn btn-success"
           >
-          {{ $t("settings.updateSettings") }}
+            {{ $t("settings.updateSettings") }}
           </button>
           <br /><br />
         </div>
@@ -246,9 +292,16 @@ export default {
           };
         })
         .catch((err) => {
-          this.error = {
-            type: "error",
-            msg: this.$t("settings.message.settingsNotUpdated", { error: err }),
+          if (err.status == 400) {
+            this.error = {
+              type: "error",
+              msg: this.$t("settings.message.settingsUpdateClientError"),
+            };
+          } else {
+            this.error = {
+              type: "error",
+              msg: this.$t("settings.message.settingsUpdateUnknownError"),
+            };
           };
         })
         .finally(() => {


### PR DESCRIPTION
This PR:
- Adds missing i18n tags for error messages and the Help page
- Reduce unnecessary calls to backend
- Add rate limit logging server-side
- Add a new setting for showing / hiding patch numbers
- Add server-side settings validation